### PR TITLE
Docs Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 AmoebotSim.pro.*
 docs/build/*
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You're welcome to do pretty much anything you'd like with our code, but you cann
 >
 > You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 >
-> AmoebotSim is developed using Qt under Open Source Usage.
+> AmoebotSim is developed using Open Source Qt.
 
 
 ## Contact Us

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ AmoebotSim is licensed under the [GNU General Public License v3.0](https://choos
 You're welcome to do pretty much anything you'd like with our code, but you cannot distribute a closed source version commercially and you must keep all copyright and license notices intact.
 
 > AmoebotSim: a visual simulator for the amoebot model of programmable matter.
-> Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+> Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
 > Please direct all questions and communications to sopslab@asu.edu.
 >
 > This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -39,6 +39,8 @@ You're welcome to do pretty much anything you'd like with our code, but you cann
 > This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 >
 > You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+>
+> AmoebotSim is developed using Qt under Open Source Usage.
 
 
 ## Contact Us

--- a/alg/compression.cpp
+++ b/alg/compression.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/compression.h
+++ b/alg/compression.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/discodemo.cpp
+++ b/alg/demo/discodemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/discodemo.h
+++ b/alg/demo/discodemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/pulldemo.cpp
+++ b/alg/demo/pulldemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/pulldemo.h
+++ b/alg/demo/pulldemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/tokendemo.cpp
+++ b/alg/demo/tokendemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/tokendemo.h
+++ b/alg/demo/tokendemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/infobjcoating.cpp
+++ b/alg/infobjcoating.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/infobjcoating.h
+++ b/alg/infobjcoating.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/leaderelection.cpp
+++ b/alg/leaderelection.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/leaderelection.h
+++ b/alg/leaderelection.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/shapeformation.cpp
+++ b/alg/shapeformation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/shapeformation.h
+++ b/alg/shapeformation.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotparticle.cpp
+++ b/core/amoebotparticle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotparticle.h
+++ b/core/amoebotparticle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotsystem.cpp
+++ b/core/amoebotsystem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotsystem.h
+++ b/core/amoebotsystem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/localparticle.cpp
+++ b/core/localparticle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 
@@ -339,6 +339,6 @@ bool LocalParticle::pointsAtMyTail(const LocalParticle& nbr, int nbrLabel)
     const {
   Q_ASSERT(isExpanded());
   Q_ASSERT(0 <= nbrLabel && nbrLabel < 10);
-  
+
   return nbr.nbrNodeReachedViaLabel(nbrLabel) == tail();
 }

--- a/core/localparticle.h
+++ b/core/localparticle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/metric.cpp
+++ b/core/metric.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/metric.h
+++ b/core/metric.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/node.h
+++ b/core/node.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/object.h
+++ b/core/object.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/particle.cpp
+++ b/core/particle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/particle.h
+++ b/core/particle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/simulator.cpp
+++ b/core/simulator.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/simulator.h
+++ b/core/simulator.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/system.cpp
+++ b/core/system.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/system.h
+++ b/core/system.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/docs/source/development/development.rst
+++ b/docs/source/development/development.rst
@@ -183,7 +183,7 @@ The following code snippet shows the important elements of your header file.
 
 .. code-block:: c++
 
-  /* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,6 +104,8 @@ You're welcome to do pretty much anything you'd like with our code, but you cann
 
   You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+  AmoebotSim is developed using Open Source Qt.
+
 
 Citing AmoebotSim
 -----------------

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -49,6 +49,19 @@ This walkthrough will assume you're using GitKraken.
 AmoebotSim's source code should now be in the directory you specified.
 
 
+Installing Sphinx
+^^^^^^^^^^^^^^^^^
+
+These docs are written in reStructuredText and built using `Sphinx <https://www.sphinx-doc.org>`_.
+If you want to edit these docs and preview them on your own machine, follow these instructions:
+
+#. Follow the `Sphinx installation instructions <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ for your platform.
+#. Use ``pip`` to install the ReadTheDocs theme: ``pip install sphinx_rtd_theme``.
+#. On the command line, navigate to the ``docs/`` directory of AmoebotSim.
+#. Run the ``make html`` command to build the docs.
+#. Preview the docs by opening ``docs/build/html/index.html`` in your browser of choice.
+
+
 Installing Qt
 ^^^^^^^^^^^^^
 
@@ -58,11 +71,21 @@ Please follow these instructions carefully, as many small deviations can cause i
 #. Navigate to Qt's `download page <https://www.qt.io/download>`_ and choose the "Go open source" option under "Downloads for open source users".
 #. Scroll to the bottom of the page and select "Download the Qt Online Installer".
 #. Download the correct version of the installer for your operating system.
-#. Run the installer. You can skip the step asking for your Qt login if you don't have one.
-#. On the "Select Components" screen, locate the ``Qt`` tab (you can ignore ``Preview``) and choose the components listed below. Note that you do not need any other components; these can be unselected to dramatically decrease the application size and installation time.
+#. Run the installer. Due to recent `Qt offering changes <https://www.qt.io/blog/qt-offering-changes-2020>`_, you will have to create a Qt account.
+#. On the "Select Components" screen, locate the ``Qt`` tab and choose the components listed below. Note that you do not need any other components; these can be unselected to dramatically decrease the application size and installation time.
 #. Agree to the licenses and install.
 
-You should select the following Qt components:
+You should select the following Qt components.
+
+* Under the subtab for the latest Qt version, e.g., ``Qt > Qt 5.14.1``, choose:
+
+  * The latest components for your platform. On macOS, this is ``macOS``; on Windows, this is the latest MinGW toolchain, e.g., [TODO]. Note that there may be 32-bit and 64-bit version to choose from; you should choose the latest version for your architecture.
+  * The latest Qt source components, ``Sources``.
+  * The latest scripting engine, ``Qt Script (Deprecated)``.
+
+* Under the ``Developer and Designer Tools`` subtab, choose:
+
+  * The latest 3D graphics library, e.g., ``Qt 3D Studio 2.6.0``.
 
 .. todo::
   Need to verify all of the above instructions and then actually do the installer with some version that works.
@@ -77,13 +100,7 @@ With the repository cloned and Qt installed, the only thing that's left to do is
 #. Select "Projects" in the left sidebar, and in the next-left sidebar that appears, choose "Build" under "Build & Run" (this may already be selected).
 #. At the top of the page next to "Edit build configuration", choose "Debug" from the first drop-down menu.
 #. For "General > Build Directory", choose a directory *outside* the repository directory housing the AmoebotSim source code (otherwise, you will need to add the build directory to your ``.gitignore``).
-#. Select "Build Steps > qmake > Enable QML debugging and profiling".
-#. Set "Build Steps > make > Parallel jobs" to the number of cores on your machine.
-
-    .. note::
-      This will considerably increase memory usage during compilation.
-
-#. Repeat Steps 3, 4, and 6 for the "Profile" and "Release" configurations, but do not enable QML debugging and profiling.
+Repeat this step for the "Profile" and "Release" configurations, targeting different build directories for each.
 #. If you are using Windows, select "Run" under "Build & Run" in the second-left sidebar. Under "Run Environment", look for an environment variable called ``QT_OPENGL``. If this variable exists, make sure its value is ``desktop``.
 
     .. todo::

--- a/docs/source/install/install.rst
+++ b/docs/source/install/install.rst
@@ -75,20 +75,11 @@ Please follow these instructions carefully, as many small deviations can cause i
 #. On the "Select Components" screen, locate the ``Qt`` tab and choose the components listed below. Note that you do not need any other components; these can be unselected to dramatically decrease the application size and installation time.
 #. Agree to the licenses and install.
 
-You should select the following Qt components.
+Under the subtab for the latest Qt version, e.g., ``Qt > Qt 5.14.1``, select the following Qt components:
 
-* Under the subtab for the latest Qt version, e.g., ``Qt > Qt 5.14.1``, choose:
-
-  * The latest components for your platform. On macOS, this is ``macOS``; on Windows, this is the latest MinGW toolchain, e.g., [TODO]. Note that there may be 32-bit and 64-bit version to choose from; you should choose the latest version for your architecture.
-  * The latest Qt source components, ``Sources``.
-  * The latest scripting engine, ``Qt Script (Deprecated)``.
-
-* Under the ``Developer and Designer Tools`` subtab, choose:
-
-  * The latest 3D graphics library, e.g., ``Qt 3D Studio 2.6.0``.
-
-.. todo::
-  Need to verify all of the above instructions and then actually do the installer with some version that works.
+* The latest prebuilt components for your platform. On macOS, this is ``macOS``; on Windows, this is the latest MinGW toolchain, e.g., ``MinGW 7.3.0 64-bit``. Note that on Windows there may be 32-bit and 64-bit versions to choose from; you should choose the latest version for your architecture.
+* The latest Qt source components, ``Sources``.
+* The latest scripting engine, ``Qt Script (Deprecated)``.
 
 
 Configuring, Building, and Running AmoebotSim
@@ -99,11 +90,5 @@ With the repository cloned and Qt installed, the only thing that's left to do is
 #. Open AmoebotSim in Qt Creator by opening ``AmoebotSim.pro`` in the repository directory.
 #. Select "Projects" in the left sidebar, and in the next-left sidebar that appears, choose "Build" under "Build & Run" (this may already be selected).
 #. At the top of the page next to "Edit build configuration", choose "Debug" from the first drop-down menu.
-#. For "General > Build Directory", choose a directory *outside* the repository directory housing the AmoebotSim source code (otherwise, you will need to add the build directory to your ``.gitignore``).
-Repeat this step for the "Profile" and "Release" configurations, targeting different build directories for each.
-#. If you are using Windows, select "Run" under "Build & Run" in the second-left sidebar. Under "Run Environment", look for an environment variable called ``QT_OPENGL``. If this variable exists, make sure its value is ``desktop``.
-
-    .. todo::
-      Check if this is still an issue with the updated Qt versions.
-
+#. For "General > Build Directory", choose a directory *outside* the repository directory housing the AmoebotSim source code (otherwise, you will need to add the build directory to your ``.gitignore``). Repeat this step for the "Profile" and "Release" configurations, targeting different build directories for each.
 #. In the bottom-left of Qt Creator, set the configuration back to "Debug" (best for development) and click the green arrow to build and run. AmoebotSim should appear.

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -146,7 +146,7 @@ With all these elements in place, we have the following:
 
 .. code-block:: c++
 
-  /* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 
@@ -292,7 +292,7 @@ It begins with the copyright notice and an ``#include`` of the header file, and 
 
 .. code-block:: c++
 
-  /* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 

--- a/helper/randomnumbergenerator.cpp
+++ b/helper/randomnumbergenerator.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/helper/randomnumbergenerator.h
+++ b/helper/randomnumbergenerator.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/application.cpp
+++ b/main/application.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/application.h
+++ b/main/application.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License along with
  * this program. If not, see <https://www.gnu.org/licenses/>.
  *
- * AmoebotSim is developed using Qt under Open Source Usage. */
+ * AmoebotSim is developed using Open Source Qt. */
 
 #include "application.h"
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,5 +1,5 @@
 /* AmoebotSim: a visual simulator for the amoebot model of programmable matter.
- * Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+ * Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * Please direct all questions and communications to sopslab@asu.edu.
  *
  * This program is free software: you can redistribute it and/or modify it under
@@ -13,7 +13,9 @@
  * details.
  *
  * You should have received a copy of the GNU General Public License along with
- * this program. If not, see <https://www.gnu.org/licenses/>. */
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * AmoebotSim is developed using Qt under Open Source Usage. */
 
 #include "application.h"
 

--- a/res/qml/A_Button.qml
+++ b/res/qml/A_Button.qml
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/res/qml/A_Inspector.qml
+++ b/res/qml/A_Inspector.qml
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/res/qml/A_ResultTextField.qml
+++ b/res/qml/A_ResultTextField.qml
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/res/qml/A_TextField.qml
+++ b/res/qml/A_TextField.qml
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/res/qml/main.qml
+++ b/res/qml/main.qml
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptengine.cpp
+++ b/script/scriptengine.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptengine.h
+++ b/script/scriptengine.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/algorithm.cpp
+++ b/ui/algorithm.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/algorithm.h
+++ b/ui/algorithm.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/commandhistorymanager.cpp
+++ b/ui/commandhistorymanager.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/commandhistorymanager.h
+++ b/ui/commandhistorymanager.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/glitem.cpp
+++ b/ui/glitem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/glitem.h
+++ b/ui/glitem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/parameterlistmodel.cpp
+++ b/ui/parameterlistmodel.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/parameterlistmodel.h
+++ b/ui/parameterlistmodel.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/view.h
+++ b/ui/view.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/visitem.cpp
+++ b/ui/visitem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/visitem.h
+++ b/ui/visitem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 


### PR DESCRIPTION
This PR updates the following documentation-related information:
- All copyrights now reflect that it is 2020.
- The installation instructions have been revised and verified, adding a section about Sphinx and removing unnecessary Qt instructions.
- Language has been added to the license regarding Qt's updated offerings, which require that we explicitly state our open source code is developed with Qt.

This PR resolves #6, as the Development docs do address deployment and the installation instructions in this PR verify that this is possible with the given Qt components.