### PR TITLE
Metrics scripting interface improvement

### DIFF
--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -71,8 +71,8 @@ void ScriptInterface::exportMetrics() {
   log("Metrics exported to application directory.");
 }
 
-QVariant ScriptInterface::getMetrics(QString name, QString mode) {
-  if (mode == "v") {
+QVariant ScriptInterface::getMetrics(QString name, bool history) {
+  if (!history) {
     for (const auto& c : sim.getSystem()->getCounts()) {
       if (c->_name == name) {
         return c->_value;
@@ -85,7 +85,7 @@ QVariant ScriptInterface::getMetrics(QString name, QString mode) {
     }
     log("no metrics with given name exist", true);
   }
-  else if (mode == "h") {
+  else {
     for (const auto& c : sim.getSystem()->getCounts()) {
       if (c->_name == name) {
         return QVariant::fromValue(c->_history);
@@ -98,9 +98,7 @@ QVariant ScriptInterface::getMetrics(QString name, QString mode) {
     }
     log("no metrics with given name exist", true);
   }
-  else {
-    log("only accepted modes for getMetrics(): 'v', 'h'", true);
-  }
+  return QVariant();
 }
 
 void ScriptInterface::setWindowSize(int width, int height) {

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -71,6 +71,38 @@ void ScriptInterface::exportMetrics() {
   log("Metrics exported to application directory.");
 }
 
+QVariant ScriptInterface::getMetrics(QString name, QString mode) {
+  if (mode == "v") {
+    for (const auto& c : sim.getSystem()->getCounts()) {
+      if (c->_name == name) {
+        return c->_value;
+      }
+    }
+    for (const auto& m : sim.getSystem()->getMeasures()) {
+      if (m->_name == name) {
+        return m->_history.back();
+      }
+    }
+    log("no metrics with given name exist", true);
+  }
+  else if (mode == "h") {
+    for (const auto& c : sim.getSystem()->getCounts()) {
+      if (c->_name == name) {
+        return QVariant::fromValue(c->_history);
+      }
+    }
+    for (const auto& m : sim.getSystem()->getMeasures()) {
+      if (m->_name == name) {
+        return QVariant::fromValue(m->_history);
+      }
+    }
+    log("no metrics with given name exist", true);
+  }
+  else {
+    log("only accepted modes for getMetrics(): 'v', 'h'", true);
+  }
+}
+
 void ScriptInterface::setWindowSize(int width, int height) {
   if(vis != nullptr) {
     vis->setWindowSize(width, height);

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -72,20 +72,7 @@ void ScriptInterface::exportMetrics() {
 }
 
 QVariant ScriptInterface::getMetrics(QString name, bool history) {
-  if (!history) {
-    for (const auto& c : sim.getSystem()->getCounts()) {
-      if (c->_name == name) {
-        return c->_value;
-      }
-    }
-    for (const auto& m : sim.getSystem()->getMeasures()) {
-      if (m->_name == name) {
-        return m->_history.back();
-      }
-    }
-    log("no metrics with given name exist", true);
-  }
-  else {
+  if (history) {
     for (const auto& c : sim.getSystem()->getCounts()) {
       if (c->_name == name) {
         return QVariant::fromValue(c->_history);
@@ -94,6 +81,19 @@ QVariant ScriptInterface::getMetrics(QString name, bool history) {
     for (const auto& m : sim.getSystem()->getMeasures()) {
       if (m->_name == name) {
         return QVariant::fromValue(m->_history);
+      }
+    }
+    log("no metrics with given name exist", true);
+  }
+  else {
+    for (const auto& c : sim.getSystem()->getCounts()) {
+      if (c->_name == name) {
+        return c->_value;
+      }
+    }
+    for (const auto& m : sim.getSystem()->getMeasures()) {
+      if (m->_name == name) {
+        return m->_history.back();
       }
     }
     log("no metrics with given name exist", true);

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -71,7 +71,7 @@ void ScriptInterface::exportMetrics() {
   log("Metrics exported to application directory.");
 }
 
-QVariant ScriptInterface::getMetrics(QString name, bool history) {
+QVariant ScriptInterface::getMetric(QString name, bool history) {
   for (const auto& c : sim.getSystem()->getCounts()) {
     if (c->_name == name) {
       return history ? QVariant::fromValue(c->_history) : c->_value;

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -72,32 +72,17 @@ void ScriptInterface::exportMetrics() {
 }
 
 QVariant ScriptInterface::getMetrics(QString name, bool history) {
-  if (history) {
-    for (const auto& c : sim.getSystem()->getCounts()) {
-      if (c->_name == name) {
-        return QVariant::fromValue(c->_history);
-      }
+  for (const auto& c : sim.getSystem()->getCounts()) {
+    if (c->_name == name) {
+      return history ? QVariant::fromValue(c->_history) : c->_value;
     }
-    for (const auto& m : sim.getSystem()->getMeasures()) {
-      if (m->_name == name) {
-        return QVariant::fromValue(m->_history);
-      }
-    }
-    log("no metrics with given name exist", true);
   }
-  else {
-    for (const auto& c : sim.getSystem()->getCounts()) {
-      if (c->_name == name) {
-        return c->_value;
-      }
+  for (const auto& m : sim.getSystem()->getMeasures()) {
+    if (m->_name == name) {
+      return history ? QVariant::fromValue(m->_history) : m->_history.back();
     }
-    for (const auto& m : sim.getSystem()->getMeasures()) {
-      if (m->_name == name) {
-        return m->_history.back();
-      }
-    }
-    log("no metrics with given name exist", true);
   }
+  log("no metrics with given name exist", true);
   return QVariant();
 }
 

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -41,13 +41,13 @@ class ScriptInterface : public QObject {
   // Simulator metrics commands. getNumParticles and getNumObjects return the
   // number of particles and objects in the given instance, respectively.
   // exportMetrics writes the metrics to JSON. See simulator.h for further
-  // discussion. getMetrics returns either the current value (history = false)
+  // discussion. getMetric returns either the current value (history = false)
   // or the historical data (history = true) of the metric with parameter-
   // defined name.
   int getNumParticles();
   int getNumObjects();
   void exportMetrics();
-  QVariant getMetrics(QString name, bool history = false);
+  QVariant getMetric(QString name, bool history = false);
 
   // Visualization commands. focusOn centers the window at the given (x,y) node.
   // setZoom sets the zoom level of the window. saveScreenshot saves the current

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -41,10 +41,12 @@ class ScriptInterface : public QObject {
   // Simulator metrics commands. getNumParticles and getNumObjects return the
   // number of particles and objects in the given instance, respectively.
   // exportMetrics writes the metrics to JSON. See simulator.h for further
-  // discussion.
+  // discussion. getMetrics returns either the current value (mode = 'v') or the
+  // entire history (mode = 'h') of the metric with parameter-defined name.
   int getNumParticles();
   int getNumObjects();
   void exportMetrics();
+  QVariant getMetrics(QString name, QString mode);
 
   // Visualization commands. focusOn centers the window at the given (x,y) node.
   // setZoom sets the zoom level of the window. saveScreenshot saves the current

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -41,12 +41,13 @@ class ScriptInterface : public QObject {
   // Simulator metrics commands. getNumParticles and getNumObjects return the
   // number of particles and objects in the given instance, respectively.
   // exportMetrics writes the metrics to JSON. See simulator.h for further
-  // discussion. getMetrics returns either the current value (mode = 'v') or the
-  // entire history (mode = 'h') of the metric with parameter-defined name.
+  // discussion. getMetrics returns either the current value (history = false)
+  // or the entire history (history = true) of the metric with parameter-defined
+  // name.
   int getNumParticles();
   int getNumObjects();
   void exportMetrics();
-  QVariant getMetrics(QString name, QString mode);
+  QVariant getMetrics(QString name, bool history = false);
 
   // Visualization commands. focusOn centers the window at the given (x,y) node.
   // setZoom sets the zoom level of the window. saveScreenshot saves the current

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -42,8 +42,8 @@ class ScriptInterface : public QObject {
   // number of particles and objects in the given instance, respectively.
   // exportMetrics writes the metrics to JSON. See simulator.h for further
   // discussion. getMetrics returns either the current value (history = false)
-  // or the entire history (history = true) of the metric with parameter-defined
-  // name.
+  // or the historical data (history = true) of the metric with parameter-
+  // defined name.
   int getNumParticles();
   int getNumObjects();
   void exportMetrics();


### PR DESCRIPTION
Adds `getMetrics(string name, bool history)` function/command to the scripting interface in order to make metrics' data visible to scripts.

Resolves #35.