### PR TITLE
Copyright 2021 and Documentation TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ AmoebotSim is licensed under the [GNU General Public License v3.0](https://choos
 You're welcome to do pretty much anything you'd like with our code, but you cannot distribute a closed source version commercially and you must keep all copyright and license notices intact.
 
 > AmoebotSim: a visual simulator for the amoebot model of programmable matter.
-> Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+> Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
 > Please direct all questions and communications to sopslab@asu.edu.
 >
 > This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/alg/compression.cpp
+++ b/alg/compression.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/compression.h
+++ b/alg/compression.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/ballroomdemo.cpp
+++ b/alg/demo/ballroomdemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/ballroomdemo.h
+++ b/alg/demo/ballroomdemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/discodemo.cpp
+++ b/alg/demo/discodemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/discodemo.h
+++ b/alg/demo/discodemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/metricsdemo.cpp
+++ b/alg/demo/metricsdemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/metricsdemo.h
+++ b/alg/demo/metricsdemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/tokendemo.cpp
+++ b/alg/demo/tokendemo.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/demo/tokendemo.h
+++ b/alg/demo/tokendemo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/energyshape.cpp
+++ b/alg/energyshape.cpp
@@ -1,3 +1,7 @@
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+ * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
+ * notice can be found at the top of main/main.cpp. */
+
 #include "alg/energyshape.h"
 
 #include <algorithm>

--- a/alg/energyshape.h
+++ b/alg/energyshape.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/energysharing.cpp
+++ b/alg/energysharing.cpp
@@ -1,3 +1,7 @@
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+ * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
+ * notice can be found at the top of main/main.cpp. */
+
 #include "alg/energysharing.h"
 
 #include <algorithm>  // for std::min, std::max.

--- a/alg/energysharing.h
+++ b/alg/energysharing.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/infobjcoating.cpp
+++ b/alg/infobjcoating.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/infobjcoating.h
+++ b/alg/infobjcoating.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/leaderelection.cpp
+++ b/alg/leaderelection.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/leaderelection.h
+++ b/alg/leaderelection.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/shapeformation.cpp
+++ b/alg/shapeformation.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/alg/shapeformation.h
+++ b/alg/shapeformation.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotparticle.cpp
+++ b/core/amoebotparticle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotparticle.h
+++ b/core/amoebotparticle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotsystem.cpp
+++ b/core/amoebotsystem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/amoebotsystem.h
+++ b/core/amoebotsystem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/localparticle.cpp
+++ b/core/localparticle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/localparticle.h
+++ b/core/localparticle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/metric.cpp
+++ b/core/metric.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/metric.h
+++ b/core/metric.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/node.h
+++ b/core/node.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/object.h
+++ b/core/object.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/particle.cpp
+++ b/core/particle.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/particle.h
+++ b/core/particle.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/simulator.cpp
+++ b/core/simulator.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/simulator.h
+++ b/core/simulator.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/system.cpp
+++ b/core/system.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/core/system.h
+++ b/core/system.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'AmoebotSim'
-copyright = '2020, Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal'
+copyright = '2021, Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal'
 author = 'Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/development/development.rst
+++ b/docs/source/development/development.rst
@@ -183,7 +183,7 @@ The following code snippet shows the important elements of your header file.
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,15 +12,12 @@ AmoebotSim
 ==========
 
 Welcome to `AmoebotSim <https://github.com/SOPSLab/AmoebotSim>`_, a visual simulator for the amoebot model developed by the `Self-Organizing Particle Systems (SOPS) Lab <https://sops.engineering.asu.edu/>`_ at Arizona State University and the University of Paderborn.
-The `amoebot model <link-todo>`_ is an abstraction of *programmable matter*, a material that can dynamically change its physical properties (e.g., shape, size, color, etc.) based on user input or stimuli from its environment.
+The `amoebot model <https://sops.engineering.asu.edu/sops/amoebot/>`_ is an abstraction of *programmable matter*, a material that can dynamically change its physical properties (e.g., shape, size, color, etc.) based on user input or stimuli from its environment.
 This simulator is designed for students and researchers who want to:
 
 * Visualize and learn about current distributed algorithms for the amoebot model
 * Experiment with new ideas for amoebot model algorithms
 * Validate correctness and runtime claims for new or existing amoebot model algorithms
-
-.. todo::
-  Need to add a link under "amoebot model" that points to the website's dedicated page for the chapter once it exists.
 
 
 Getting Started
@@ -76,14 +73,21 @@ All development best practices and guidelines for contributions are discussed un
 Acknowledgements
 ----------------
 
-AmoebotSim was originally created by `Robert Gmyr <https://gmyr.net/>`_ during his PhD studies at the University of Paderborn, and is now actively maintained by `Joshua J. Daymude <https://github.com/jdaymude>`_ and `Kristian Hinnenthal <link-todo>`_, current PhD students in the SOPS Lab.
+AmoebotSim was originally created by `Robert Gmyr <https://gmyr.net/>`_ during his PhD studies at the University of Paderborn, and is now actively maintained by `Joshua J. Daymude <https://github.com/jdaymude>`_ and other members of the SOPS Lab.
 Many other hands have helped (and are currently helping) build AmoebotSim.
 We'd like to thank:
 
-*
-
-.. todo::
-  Need to add a GitHub account for Kristian and need to fill out past contributors.
+* `Joseph Briones <https://github.com/josephbriones>`_
+* `Noble Harasha <https://github.com/nharasha1202>`_
+* `Jamison Weber <https://github.com/jwweber>`_
+* Kristian Hinnenthal
+* `Ryan Yiu <https://github.com/ryanyiu>`_
+* `Ziad Abdelkarim <https://github.com/ZiadAbdelkarim>`_
+* `Kevin Lough <https://github.com/kjlough>`_
+* Alexandra Porter
+* `Zahra Derakhshandeh <https://www.zderakhshandeh.com/>`_
+* Stainslaw Eppinger
+* `Brian Parker <https://github.com/rparker214>`_
 
 
 Licensing
@@ -93,7 +97,7 @@ AmoebotSim is licensed under the `GNU General Public License v3.0 <https://choos
 You're welcome to do pretty much anything you'd like with our code, but you cannot distribute a closed source version commercially and you must keep all copyright and license notices intact.
 
   AmoebotSim: a visual simulator for the amoebot model of programmable matter.
-  Copyright (C) 2019 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
   Please direct all questions and communications to sopslab@asu.edu.
 
   This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
@@ -110,19 +114,18 @@ Citing AmoebotSim
 
 If you utilize AmoebotSim in your research, we ask that you cite the project as:
 
-  TODO
-
-.. todo::
-  Need to figure out what the citation would actually be.
+  Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal. "AmoebotSim: A Visual Simulator for the Amoebot Model of Programmable Matter", Available online at `https://github.com/SOPSLab/AmoebotSim <https://github.com/SOPSLab/AmoebotSim>`_, 2021.
 
 You can also use the following BibTeX entry, if more convenient:
 
 .. code-block:: tex
 
-  TODO
-
-.. todo::
-  Need to build out the BibTeX reference.
+  @unpublished{Daymude2021-amoebotsim,
+    title = {{AmoebotSim: A Visual Simulator for the Amoebot Model of Programmable Matter}},
+    author = {Daymude, Joshua J. and Gmyr, Robert and Hinnenthal, Kristian},
+    year = {2021},
+    note = {Available online at \url{https://github.com/SOPSLab/AmoebotSim}}
+  }
 
 
 .. _faqs:
@@ -130,8 +133,7 @@ You can also use the following BibTeX entry, if more convenient:
 FAQs
 ----
 
-.. todo::
-  Coming soon!
+We'll add frequently-asked questions in the future as they become relevant.
 
 
 .. _contact-us:
@@ -148,6 +150,3 @@ Changelog
 ---------
 
 In the future, this will contain the changelog for AmoebotSim.
-
-.. todo::
-  Coming soon!

--- a/docs/source/tutorials/tutorials.rst
+++ b/docs/source/tutorials/tutorials.rst
@@ -3,13 +3,10 @@ Tutorials
 
 These tutorials are for researchers 🧪 and developers 💻 wanting to implement distributed algorithms for programmable matter in AmoebotSim.
 As a prerequisite, make sure you've followed the instructions in the :doc:`Installation Guide </install/install>` so that everything builds and runs correctly.
-Additionally, you should be comfortable with how the `amoebot model <link-todo>`_ is defined.
+Additionally, you should be comfortable with how the `amoebot model <https://sops.engineering.asu.edu/sops/amoebot/>`_ is defined.
 
 All tutorials can be found in the ``alg/demo/`` directory of AmoebotSim so you can build and run them yourself.
 Note that the coding style in these tutorials follows our :ref:`C++ Style Guide <cpp-style>` which we will not re-explain here.
-
-.. todo::
-  Add links.
 
 
 Anatomy of AmoebotSim
@@ -31,12 +28,9 @@ AmoebotSim is organized into seven main directories that loosely collect similar
 
 * ``res/`` contains AmoebotSim's resources, including textures for graphics rendering, icons, GUI layout, etc.
 
-* ``script/`` contains the classes used for interpreting and executing commands issued to AmoebotSim via its `JavaScript API <link-todo>`_.
+* ``script/`` contains the classes used for interpreting and executing commands issued to AmoebotSim via its :ref:`JavaScript API <script-api>`.
 
 * ``ui/`` contains the classes used for front end GUI rendering and visualization.
-
-.. todo::
-  Add links.
 
 The most important classes for implemeting new distributed algorithms in AmoebotSim are:
 
@@ -148,7 +142,7 @@ With all these elements in place, we have the following:
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 
@@ -292,7 +286,7 @@ It begins with the copyright notice and an ``#include`` of the header file, and 
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 
@@ -680,7 +674,7 @@ The particle's ``_state`` variable will keep track of whether it is a leader (``
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
   * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
   * notice can be found at the top of main/main.cpp. */
 
@@ -770,7 +764,7 @@ The skeleton of ``alg/demo/ballroomdemo.cpp`` is straightforward.
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 
@@ -1127,7 +1121,7 @@ Just as with other new particle types, we inherit from ``AmoebotParticle`` and s
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 
@@ -1218,7 +1212,7 @@ We complete our setup with a skeleton of ``alg/demo/tokendemo.cpp``.
 
 .. code-block:: c++
 
-  /* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+  /* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
    * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
    * notice can be found at the top of main/main.cpp. */
 

--- a/helper/randomnumbergenerator.cpp
+++ b/helper/randomnumbergenerator.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/helper/randomnumbergenerator.h
+++ b/helper/randomnumbergenerator.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/application.cpp
+++ b/main/application.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/application.h
+++ b/main/application.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,5 +1,5 @@
 /* AmoebotSim: a visual simulator for the amoebot model of programmable matter.
- * Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+ * Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * Please direct all questions and communications to sopslab@asu.edu.
  *
  * This program is free software: you can redistribute it and/or modify it under

--- a/script/scriptengine.cpp
+++ b/script/scriptengine.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptengine.h
+++ b/script/scriptengine.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptinterface.cpp
+++ b/script/scriptinterface.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/script/scriptinterface.h
+++ b/script/scriptinterface.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/algorithm.cpp
+++ b/ui/algorithm.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 
@@ -279,9 +279,9 @@ void ShapeFormationAlg::instantiate(const int numParticles,
 
 AlgorithmList::AlgorithmList() {
   // Demo algorithms.
-  _algorithms.push_back(new DiscoDemoAlg());  
+  _algorithms.push_back(new DiscoDemoAlg());
   _algorithms.push_back(new MetricsDemoAlg());
-  _algorithms.push_back(new BallroomDemoAlg());  
+  _algorithms.push_back(new BallroomDemoAlg());
   _algorithms.push_back(new TokenDemoAlg());
   _algorithms.push_back(new DynamicDemoAlg());
 
@@ -289,7 +289,7 @@ AlgorithmList::AlgorithmList() {
   _algorithms.push_back(new CompressionAlg());
   _algorithms.push_back(new EnergyShapeAlg());
   _algorithms.push_back(new EnergySharingAlg());
-  _algorithms.push_back(new InfObjCoatingAlg());    
+  _algorithms.push_back(new InfObjCoatingAlg());
   _algorithms.push_back(new LeaderElectionAlg());
   _algorithms.push_back(new ShapeFormationAlg());
 }

--- a/ui/algorithm.h
+++ b/ui/algorithm.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/glitem.cpp
+++ b/ui/glitem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/glitem.h
+++ b/ui/glitem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/parameterlistmodel.cpp
+++ b/ui/parameterlistmodel.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/parameterlistmodel.h
+++ b/ui/parameterlistmodel.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/view.cpp
+++ b/ui/view.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/view.h
+++ b/ui/view.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/visitem.cpp
+++ b/ui/visitem.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 

--- a/ui/visitem.h
+++ b/ui/visitem.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
+/* Copyright (C) 2021 Joshua J. Daymude, Robert Gmyr, and Kristian Hinnenthal.
  * The full GNU GPLv3 can be found in the LICENSE file, and the full copyright
  * notice can be found at the top of main/main.cpp. */
 


### PR DESCRIPTION
This PR updates all copyright statements in the repository (at the top of all source files, in the README, and throughout the documentation) to reflect our continued copyright into 2021. It also addresses all outstanding TODOs and missing links in the documentation.

Resolves #54.

Pushing this through without review because it only affects build correctness, which I've verified on both platforms.