### PR TITLE
Fix segfault at application start under gcc on linux

### DIFF
--- a/main/application.cpp
+++ b/main/application.cpp
@@ -12,7 +12,7 @@
 
 #include "ui/visitem.h"
 
-Application::Application(int argc, char *argv[])
+Application::Application(int &argc, char *argv[])
     : QGuiApplication(argc, argv) {
   // Setup the parameter list model.
   parameterModel = new ParameterListModel();

--- a/main/application.h
+++ b/main/application.h
@@ -17,7 +17,7 @@
 class Application : public QGuiApplication {
   Q_OBJECT
  public:
-  explicit Application(int argc, char *argv[]);
+  explicit Application(int &argc, char *argv[]);
 
  protected:
   QQmlApplicationEngine engine;


### PR DESCRIPTION
As per the Qt5 QApplication documentation (https://doc.qt.io/qt-5/qapplication.html#QApplication):

> Warning: The data referred to by argc and argv must stay valid for the entire lifetime of the QApplication object. In addition, argc must be greater than zero and argv must contain at least one valid character string.

Currently, argc is is passed by value, which goes out of scope at the end of the Application constructor. Under mingw this was not an issue. However, under gcc (on linux) a segfault occurs when trying to run the application. Passing by reference fixes this issue.